### PR TITLE
Redirect to mete to add barcode on click

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -90,7 +90,7 @@ export default defineComponent({
       this.menu = false;
       this.mete = true;
     },
-    addNewBarCode($event: Event, barcode: str) {
+    addNewBarCode($event: Event, barcode: string) {
       $event.preventDefault();
 
       this.meteUrl = '/mete/barcodes/new?id=' + encodeURIComponent(barcode);

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@
     <el-main v-if="!mete">
       <Register ref="register" />
     </el-main>
-    <Mete v-if="mete" />
+    <Mete v-if="mete" :url='meteUrl' />
   </el-container>
 </template>
 
@@ -49,6 +49,7 @@ export default defineComponent({
     return {
       menu: false,
       mete: false,
+      meteUrl: '/mete',
       storno: false,
     };
   },
@@ -85,6 +86,14 @@ export default defineComponent({
     goMete($event: Event) {
       $event.preventDefault();
 
+      this.meteUrl = '/mete';
+      this.menu = false;
+      this.mete = true;
+    },
+    addNewBarCode($event: Event, barcode: str) {
+      $event.preventDefault();
+
+      this.meteUrl = '/mete/barcodes/new?id=' + encodeURIComponent(barcode);
       this.menu = false;
       this.mete = true;
     },

--- a/src/components/Mete.vue
+++ b/src/components/Mete.vue
@@ -1,5 +1,5 @@
 <template>
-  <iframe ref="mete" class="meteframe" src="/mete" />
+  <iframe ref="mete" class="meteframe" :src="url" />
 </template>
 
 <script lang="ts">
@@ -7,5 +7,11 @@ import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "Mete",
+  props: {
+    url: {
+      type: String,
+      required: true,
+    }
+  }
 });
 </script>

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -123,7 +123,7 @@ export default defineComponent({
           title: "Unbekannter Barcode!",
           message: `Klicke hier um den Barcode ${barcode} im Administrationsbereich zu hinterlegen!`,
           type: "warning",
-          onClick:($event: Event) => { this.$root.addNewBarCode($event, barcode); }
+          onClick:($event: Event) => { (this.$root as any)?.addNewBarCode($event, barcode); }
         });
       }
     },

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -121,8 +121,9 @@ export default defineComponent({
       } else {
         notify({
           title: "Unbekannter Barcode!",
-          message: `Bitte den Barcode ${barcode} im Administrationsbereich hinterlegen!`,
+          message: `Klicke hier um den Barcode ${barcode} im Administrationsbereich zu hinterlegen!`,
           type: "warning",
+          onClick:($event: Event) => { this.$root.addNewBarCode($event, barcode); }
         });
       }
     },


### PR DESCRIPTION
Add the option to click on the warning that the barcode is not known, so that we can directly add it in mete.

To achieve this I added the `url` prop to `Mete.vue`.

NOTE: I had to cast `this.$root` to any - if you have better ideas please share!

I assume this is quite hacky - nicer approaches welcome.

And help wanted to fix the checks :upside_down_face: 

To test this add `this.addFromBarcode('asdf?!<');` to `Register.vue`'s `mounted` function.
